### PR TITLE
Goreleaser API Change update

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,6 @@ jobs:
         with:
           distribution: goreleaser
           version: '~> v1'
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update usage of goreleaser, since --rm-dist was deprecated and replaced with --clean arg.