### PR TITLE
fix entry point to use updated executable name.

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 - id: addlicense
   name: addlicense
   description: Add copyright license header to source code.
-  entry: addlicense
+  entry: addlicense-pre-commit
   types: [text]
   language: golang
   minimum_pre_commit_version: 3.0.0


### PR DESCRIPTION
Since the go.mod was updated to reflect the current repository, the name of the executable has changed to reflect the repository name (from addlicense => addlicense-pre-commit). This updates the pre commit hook config to use this corrected executable name as an entry for the hook.